### PR TITLE
Feature: add pod last restart column to pod section (#2946)

### DIFF
--- a/internal/model/table_int_test.go
+++ b/internal/model/table_int_test.go
@@ -35,7 +35,7 @@ func TestTableReconcile(t *testing.T) {
 	err := ta.reconcile(ctx)
 	assert.Nil(t, err)
 	data := ta.Peek()
-	assert.Equal(t, 23, data.HeaderCount())
+	assert.Equal(t, 24, data.HeaderCount())
 	assert.Equal(t, 1, data.RowCount())
 	assert.Equal(t, client.NamespaceAll, data.GetNamespace())
 }

--- a/internal/model/table_test.go
+++ b/internal/model/table_test.go
@@ -36,7 +36,7 @@ func TestTableRefresh(t *testing.T) {
 	ctx = context.WithValue(ctx, internal.KeyWithMetrics, false)
 	assert.NoError(t, ta.Refresh(ctx))
 	data := ta.Peek()
-	assert.Equal(t, 23, data.HeaderCount())
+	assert.Equal(t, 24, data.HeaderCount())
 	assert.Equal(t, 1, data.RowCount())
 	assert.Equal(t, client.NamespaceAll, data.GetNamespace())
 	assert.Equal(t, 1, l.count)

--- a/internal/render/helpers_test.go
+++ b/internal/render/helpers_test.go
@@ -54,7 +54,7 @@ func TestTableHydrate(t *testing.T) {
 
 	assert.Nil(t, model1.Hydrate("blee", oo, rr, Pod{}))
 	assert.Equal(t, 1, len(rr))
-	assert.Equal(t, 23, len(rr[0].Fields))
+	assert.Equal(t, 24, len(rr[0].Fields))
 }
 
 func TestToAge(t *testing.T) {

--- a/internal/render/pod_test.go
+++ b/internal/render/pod_test.go
@@ -163,8 +163,8 @@ func TestPodRender(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "default/nginx", r.ID)
-	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Running", "0", "100", "50", "100:0", "70:170", "100", "n/a", "71", "29", "172.17.0.6", "minikube", "<none>", "<none>"}
-	assert.Equal(t, e, r.Fields[:19])
+	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Running", "0", "<unknown>", "100", "50", "100:0", "70:170", "100", "n/a", "71", "29", "172.17.0.6", "minikube", "<none>", "<none>"}
+	assert.Equal(t, e, r.Fields[:20])
 }
 
 func BenchmarkPodRender(b *testing.B) {
@@ -194,8 +194,8 @@ func TestPodInitRender(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "default/nginx", r.ID)
-	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Init:0/1", "0", "10", "10", "100:0", "70:170", "10", "n/a", "14", "5", "172.17.0.6", "minikube", "<none>", "<none>"}
-	assert.Equal(t, e, r.Fields[:19])
+	e := model1.Fields{"default", "nginx", "0", "●", "1/1", "Init:0/1", "0", "<unknown>", "10", "10", "100:0", "70:170", "10", "n/a", "14", "5", "172.17.0.6", "minikube", "<none>", "<none>"}
+	assert.Equal(t, e, r.Fields[:20])
 }
 
 func TestPodSidecarRender(t *testing.T) {
@@ -210,8 +210,8 @@ func TestPodSidecarRender(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, "default/sleep", r.ID)
-	e := model1.Fields{"default", "sleep", "0", "●", "1/1", "Running", "0", "100", "40", "50:250", "50:80", "200", "40", "80", "50", "10.244.0.8", "kind-control-plane", "<none>", "<none>"}
-	assert.Equal(t, e, r.Fields[:19])
+	e := model1.Fields{"default", "sleep", "0", "●", "1/1", "Running", "0", "<unknown>", "100", "40", "50:250", "50:80", "200", "40", "80", "50", "10.244.0.8", "kind-control-plane", "<none>", "<none>"}
+	assert.Equal(t, e, r.Fields[:20])
 }
 
 func TestCheckPodStatus(t *testing.T) {


### PR DESCRIPTION
* feat: create ToRestartAge helper function to calculate last restart age

* feat: add Last Restart column to pod view

* test: add TestPodLastRestart to pod tests

* test: add TestToRestartAge tests

* test: fix all initial row states on table tests

* chore: remove TestToRestartAge changes

* refactor: move LastRestart pod function to internal function

* refactor: update to new go 1.22 range over map syntax